### PR TITLE
fix: add listener of logout completion after power resume then restart the phoneIsland

### DIFF
--- a/src/main/classes/controllers/AccountController.ts
+++ b/src/main/classes/controllers/AccountController.ts
@@ -57,7 +57,7 @@ export class AccountController {
     store.saveToDisk()
   }
 
-  async tokenLogin(): Promise<boolean> {
+  async autoLogin(): Promise<boolean> {
     //
     const authAppData = store.store['auth']
     if (authAppData?.lastUser) {

--- a/src/main/classes/controllers/PhoneIslandController.ts
+++ b/src/main/classes/controllers/PhoneIslandController.ts
@@ -118,6 +118,10 @@ export class PhoneIslandController {
 
   reconnect() {
     this.window.emit(IPC_EVENTS.RECONNECT_PHONE_ISLAND)
+    once(IPC_EVENTS.LOGOUT_COMPLETED, () => {
+      this.window.quit()
+      new PhoneIslandController()
+    })
   }
 
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -176,9 +176,6 @@ export enum PHONE_ISLAND_EVENTS {
 function getSize(normalSize: Size, collapsedSize?: Size, minimizedSize: Size = { w: 168, h: 40 }) {
   return (isExpanded: boolean = true, isMinimized: boolean = false, isDisconnected: boolean = false): Size => {
     const size = isMinimized ? minimizedSize : ((isExpanded ? normalSize : collapsedSize) || normalSize)
-    // if (isDisconnected) {
-    //   size.h += 50
-    // }
     return size
   }
 }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -176,9 +176,9 @@ export enum PHONE_ISLAND_EVENTS {
 function getSize(normalSize: Size, collapsedSize?: Size, minimizedSize: Size = { w: 168, h: 40 }) {
   return (isExpanded: boolean = true, isMinimized: boolean = false, isDisconnected: boolean = false): Size => {
     const size = isMinimized ? minimizedSize : ((isExpanded ? normalSize : collapsedSize) || normalSize)
-    if (isDisconnected) {
-      size.h += 50
-    }
+    // if (isDisconnected) {
+    //   size.h += 50
+    // }
     return size
   }
 }

--- a/src/test/index.ts
+++ b/src/test/index.ts
@@ -1,0 +1,28 @@
+import { store } from '@/lib/mainStore'
+import { onAppResume, onAppSuspend } from '@/main'
+import { useNethVoiceAPI } from '@shared/useNethVoiceAPI'
+import { log } from '@shared/utils/logger'
+import { delay } from '@shared/utils/utils'
+
+
+// TODO: ONLY FOR TEST PURPOSE - delete all references before PR
+export async function testNethlink() {
+  await delay(10000)
+  store.set('account', {
+    ...store.store.account,
+    accessToken: '1234'
+  })
+  log(store.store.account?.accessToken)
+  try {
+    const { NethVoiceAPI } = useNethVoiceAPI(store.store['account'])
+    const me = await NethVoiceAPI.User.me()
+    log('me', { me })
+  } catch (e) {
+    log(e)
+  }
+  await delay(100)
+  onAppSuspend()
+  await delay(3000)
+  await onAppResume()
+  log(store.store.account?.accessToken)
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -5,6 +5,7 @@
     "src/main/**/*",
     "src/preload/*",
     "src/shared/**/*",
+    "src/test/**/*",
   ],
   "exclude": [
     "node_modules"


### PR DESCRIPTION
When the PC goes into sleep and is subsequently reactivated with nethlink open, the phone island must detach and then be reconnected.
With this fix, a listener has been added to the LogoutCompleted event with which the phoneIsland instance is destroyed and rebuilt