### PR TITLE
fix issue #19: added a regex to eliminate spaces in the number passed to the phone island

### DIFF
--- a/src/renderer/src/hooks/usePhoneIslandEventHandler.ts
+++ b/src/renderer/src/hooks/usePhoneIslandEventHandler.ts
@@ -17,8 +17,10 @@ export const usePhoneIslandEventHandler = () => {
   const { isCallsEnabled } = useAccount()
 
   function callNumber(number: string) {
-    if (number && validatePhoneNumber(number) && isCallsEnabled)
-      window.electron.send(IPC_EVENTS.EMIT_START_CALL, number)
+    const numberCleanerRegex = /\s+/g
+    const cleanNumber = (`${number}`).replace(numberCleanerRegex, '')
+    if (number && validatePhoneNumber(cleanNumber) && isCallsEnabled)
+      window.electron.send(IPC_EVENTS.EMIT_START_CALL, cleanNumber)
     else
       log('unable to call', number)
   }

--- a/src/renderer/src/pages/PhoneIslandPage.tsx
+++ b/src/renderer/src/pages/PhoneIslandPage.tsx
@@ -85,7 +85,7 @@ export function PhoneIslandPage() {
     }))
     window.electron.receive(IPC_EVENTS.LOGOUT, logout)
 
-    window.electron.receive(IPC_EVENTS.START_CALL, (number: number | string) => {
+    window.electron.receive(IPC_EVENTS.START_CALL, (number: string) => {
       eventDispatch(PHONE_ISLAND_EVENTS['phone-island-call-start'], {
         number
       })


### PR DESCRIPTION
fix #19: added a regex in the `callNumber` function of `usePhoneIslandEventHandler` hook, to eliminate spaces in the number passed to the phone island